### PR TITLE
Add file_max and copy_max constructors

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,7 +4,7 @@
 # for simplicity we are compiling and testing everything on the Ubuntu environment only.
 # For multi-OS testing see the `cross.yml` workflow.
 
-on: [push, pull_request]
+on: [push]
 
 name: Verify
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmap"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Jeremy Larkin <jeremylarkin@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/kalamay/vmap-rs"

--- a/src/os/unix/posix/mod.rs
+++ b/src/os/unix/posix/mod.rs
@@ -71,13 +71,13 @@ pub unsafe fn unmap_ring(pg: *mut u8, len: usize) -> Result<()> {
 
 fn tmp_open(size: usize) -> Result<c_int> {
     let fd = memfd_open()?;
-    unsafe {
-        if ftruncate(fd, size as off_t) < 0 {
-            let err = Error::last_os_error();
+    if unsafe { ftruncate(fd, size as off_t) } < 0 {
+        let err = Error::last_os_error();
+        unsafe {
             close(fd);
-            Err(err)
-        } else {
-            Ok(fd)
         }
+        Err(err)
+    } else {
+        Ok(fd)
     }
 }


### PR DESCRIPTION
These new constructos allow the mapping size to exceed the file size.
When this happens, the length is shortened to match the file.