### PR TITLE
Release 0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmap"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Jeremy Larkin <jeremylarkin@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/kalamay/vmap-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,12 @@ description = "Cross-platform library for fast and safe memory-mapped IO"
 keywords = ["mmap", "io", "file", "circular-buffer", "ring-buffer"]
 edition = "2018"
 
+[features]
+default = ["all"]
+all = ["io", "os"]
+io = []
+os = []
+
 [dependencies]
 system_error = "0.1.1"
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,131 @@
 A cross-platform library for fast and safe memory-mapped IO in Rust
 
 Take a look at the [Documentation](https://docs.rs/vmap/) for details!
+
+This library defines a convenient API for reading and writing to files
+using the hosts virtual memory system. The design of the API strives to
+both minimize the frequency of mapping system calls while still retaining
+safe access. Critically, it never attempts the own the `File` object used
+for mapping. That is, it never clones it or in any way retains it. While
+this has some implications for the API (i.e. [`.flush()`]), it cannot cause
+bugs outside of this library through `File`'s leaky abstraction when cloned
+and then closed.
+
+The [`Map`] and [`MapMut`] types are primary means for allocating virtual
+memory regions, both for a file and anonymously. Generally, the
+[`Map::with_options()`] and [`MapMut::with_options()`] are used to specify
+the mapping requirements. See [`Options`] for more information.
+
+The [`MapMut`] type maintains interior mutability for the mapped memory,
+while the [`Map`] is read-only. However, it is possible to convert between
+these types ([`.into_map_mut()`] and [`.into_map()`]) assuming the proper
+[`Options`] are specified.
+
+Additionally, a variety of buffer implementations are provided in the
+[`vmap::io`] module. The [`Ring`] and [`InfiniteRing`] use circular memory
+address allocations using cross-platform optimizations to minimize excess
+resources where possible. The [`BufReader`] and [`BufWriter`] implement
+buffered I/O using a [`Ring`] as a backing layer.
+
+# Examples
+
+```rust
+use vmap::Map;
+use std::{fs, str};
+
+let path = "example";
+
+// Write some test data
+fs::write(&path, b"this is a test")?;
+
+// Map the first 4 bytes
+let (map, file) = Map::with_options().len(4).open(&path)?;
+assert_eq!(Ok("this"), str::from_utf8(&map[..]));
+
+// Reuse the file to map a different region
+let map = Map::with_options().offset(10).len(4).map(&file)?;
+assert_eq!(Ok("test"), str::from_utf8(&map[..]));
+```
+
+If opened properly, the [`Map`] can be moved into a [`MapMut`] and modifications
+to the underlying file can be performed:
+
+```rust
+use vmap::Map;
+use std::{fs, str};
+
+let path = "example";
+
+// Write some test data
+fs::write(&path, b"this is a test")?;
+
+// Open with write permissions so the Map can be converted into a MapMut
+let (map, file) = Map::with_options().write().len(14).open(&path)?;
+assert_eq!(Ok("this is a test"), str::from_utf8(&map[..]));
+
+// Move the Map into a MapMut
+// ... we could have started with MapMut::with_options()
+let mut map = map.into_map_mut()?;
+map[..4].clone_from_slice(b"that");
+
+// Flush the changes to disk synchronously
+map.flush(&file, Flush::Sync)?;
+
+// Move the MapMut back into a Map
+let map = map.into_map()?;
+assert_eq!(Ok("that is a test"), str::from_utf8(&map[..]));
+```
+
+## Ring Buffer
+
+The [`vmap`] library contains a [`Ring`] that constructs a circular memory
+allocation where values can wrap from around from the end of the buffer back
+to the beginning with sequential memory addresses. The [`InfiniteRing`] is
+similar, however it allows writes to overwrite reads.
+
+```rust
+use vmap::io::{Ring, SeqWrite};
+use std::io::{BufRead, Read, Write};
+
+let mut buf = Ring::new(4000).unwrap();
+let mut i = 1;
+
+// Fill up the buffer with lines.
+while buf.write_len() > 20 {
+    write!(&mut buf, "this is test line {}\n", i)?;
+    i += 1;
+}
+
+// No more space is available.
+assert!(write!(&mut buf, "this is test line {}\n", i).is_err());
+
+let mut line = String::new();
+
+// Read the first line written.
+let len = buf.read_line(&mut line)?;
+assert_eq!(line, "this is test line 1\n");
+
+line.clear();
+
+// Read the second line written.
+let len = buf.read_line(&mut line)?;
+assert_eq!(line, "this is test line 2\n");
+
+// Now there is enough space to write more.
+write!(&mut buf, "this is test line {}\n", i)?;
+```
+
+[`.flush()`]: https://docs.rs/vmap/0.4.2/vmap/struct.MapMut.html#method.flush
+[`.into_map()`]: https://docs.rs/vmap/0.4.2/vmap/struct.MapMut.html#method.into_map
+[`.into_map_mut()`]: https://docs.rs/vmap/0.4.2/vmap/struct.Map.html#method.into_map_mut
+[`BufReader`]: https://docs.rs/vmap/0.4.2/vmap/io/struct.BufReader.html
+[`BufWriter`]: https://docs.rs/vmap/0.4.2/vmap/io/struct.BufWriter.html
+[`InfiniteRing`]: https://docs.rs/vmap/0.4.2/vmap/io/struct.InfiniteRing.html
+[`Map::with_options()`]: https://docs.rs/vmap/0.4.2/vmap/struct.Map.html#method.with_options
+[`MapMut::with_options()`]: https://docs.rs/vmap/0.4.2/vmap/struct.MapMut.html#method.with_options
+[`MapMut`]: https://docs.rs/vmap/0.4.2/vmap/struct.MapMut.html
+[`Map`]: https://docs.rs/vmap/0.4.2/vmap/struct.Map.html
+[`Options`]: https://docs.rs/vmap/0.4.2/vmap/struct.Options.html
+[`Ring`]: https://docs.rs/vmap/0.4.2/vmap/io/struct.Ring.html
+[`vmap::io`]: https://docs.rs/vmap/0.4.2/vmap/io/index.html
+[`vmap`]: https://docs.rs/vmap/

--- a/src/io/ring.rs
+++ b/src/io/ring.rs
@@ -26,16 +26,30 @@ use std::io::{self, BufRead, Read, Write};
 /// # fn main() -> std::io::Result<()> {
 /// let mut buf = Ring::new(4000).unwrap();
 /// let mut i = 1;
+///
+/// // Fill up the buffer with lines.
 /// while buf.write_len() > 20 {
 ///     write!(&mut buf, "this is test line {}\n", i)?;
 ///     i += 1;
 /// }
+///
+/// // No more space is available.
 /// assert!(write!(&mut buf, "this is test line {}\n", i).is_err());
 ///
 /// let mut line = String::new();
+///
+/// // Read the first line written.
 /// let len = buf.read_line(&mut line)?;
-/// assert_eq!(len, 20);
 /// assert_eq!(line, "this is test line 1\n");
+///
+/// line.clear();
+///
+/// // Read the second line written.
+/// let len = buf.read_line(&mut line)?;
+/// assert_eq!(line, "this is test line 2\n");
+///
+/// // Now there is enough space to write more.
+/// write!(&mut buf, "this is test line {}\n", i)?;
 /// # Ok(())
 /// # }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,16 +3,58 @@
 //! This library defines a convenient API for reading and writing to files
 //! using the hosts virtual memory system. The design of the API strives to
 //! both minimize the frequency of mapping system calls while still retaining
-//! safe access.
+//! safe access. Critically, it never attempts the own the `File` object used
+//! for mapping. That is, it never clones it or in any way retains it. While
+//! this has some implications for the API (i.e. [`.flush()`]), it cannot cause
+//! bugs outside of this library through `File`'s leaky abstraction when cloned
+//! and then closed.
+//!
+//! The [`Map`] and [`MapMut`] types are primary means for allocating virtual
+//! memory regions, both for a file and anonymously. Generally, the
+//! [`Map::with_options()`] and [`MapMut::with_options()`] are used to specify
+//! the mapping requirements. See [`Options`] for more information.
+//!
+//! The [`MapMut`] type maintains interior mutability for the mapped memory,
+//! while the [`Map`] is read-only. However, it is possible to convert between
+//! these types ([`.into_map_mut()`] and [`.into_map()`]) assuming the proper
+//! [`Options`] are specified.
 //!
 //! Additionally, a variety of buffer implementations are provided in the
-//! [`vmap::io`](io/index.html) module.
+//! [`vmap::io`] module. The [`Ring`] and [`InfiniteRing`] use circular memory
+//! address allocations using cross-platform optimizations to minimize excess
+//! resources where possible. The [`BufReader`] and [`BufWriter`] implement
+//! buffered I/O using a [`Ring`] as a backing layer.
 //!
 //! # Examples
 //!
 //! ```
 //! use vmap::Map;
-//! use std::fs::OpenOptions;
+//! use std::path::PathBuf;
+//! use std::str::from_utf8;
+//! # use std::fs;
+//!
+//! # fn main() -> vmap::Result<()> {
+//! # let tmp = tempdir::TempDir::new("vmap")?;
+//! let path: PathBuf = /* path to file */
+//! # tmp.path().join("example");
+//! # fs::write(&path, b"this is a test")?;
+//!
+//! // Map the first 4 bytes
+//! let (map, file) = Map::with_options().len(4).open(&path)?;
+//! assert_eq!(Ok("this"), from_utf8(&map[..]));
+//!
+//! // Reuse the file to map a different region
+//! let map = Map::with_options().offset(10).len(4).map(&file)?;
+//! assert_eq!(Ok("test"), from_utf8(&map[..]));
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! If opened properly, the `Map` can be moved into a `MapMut` and modifications
+//! to the underlying file can be performed:
+//!
+//! ```
+//! use vmap::{Map, Flush};
 //! use std::path::PathBuf;
 //! use std::str::from_utf8;
 //! # use std::fs;
@@ -32,12 +74,69 @@
 //! let mut map = map.into_map_mut()?;
 //! map[..4].clone_from_slice(b"that");
 //!
+//! // Flush the changes to disk synchronously
+//! map.flush(&file, Flush::Sync)?;
+//!
 //! // Move the MapMut back into a Map
 //! let map = map.into_map()?;
 //! assert_eq!(Ok("that is a test"), from_utf8(&map[..]));
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! This library contains a [`Ring`] that constructs a circular memory
+//! allocation where values can wrap from around from the end of the buffer back
+//! to the beginning with sequential memory addresses. The [`InfiniteRing`] is
+//! similar, however it allows writes to overwrite reads.
+//!
+//! ```
+//! use vmap::io::{Ring, SeqWrite};
+//! use std::io::{BufRead, Read, Write};
+//!
+//! # fn main() -> std::io::Result<()> {
+//! let mut buf = Ring::new(4000).unwrap();
+//! let mut i = 1;
+//!
+//! // Fill up the buffer with lines.
+//! while buf.write_len() > 20 {
+//!     write!(&mut buf, "this is test line {}\n", i)?;
+//!     i += 1;
+//! }
+//!
+//! // No more space is available.
+//! assert!(write!(&mut buf, "this is test line {}\n", i).is_err());
+//!
+//! let mut line = String::new();
+//!
+//! // Read the first line written.
+//! let len = buf.read_line(&mut line)?;
+//! assert_eq!(line, "this is test line 1\n");
+//!
+//! line.clear();
+//!
+//! // Read the second line written.
+//! let len = buf.read_line(&mut line)?;
+//! assert_eq!(line, "this is test line 2\n");
+//!
+//! // Now there is enough space to write more.
+//! write!(&mut buf, "this is test line {}\n", i)?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! [`.flush()`]: struct.MapMut.html#method.flush
+//! [`.into_map()`]: struct.MapMut.html#method.into_map
+//! [`.into_map_mut()`]: struct.Map.html#method.into_map_mut
+//! [`BufReader`]: io/struct.BufReader.html
+//! [`BufWriter`]: io/struct.BufWriter.html
+//! [`InfiniteRing`]: io/struct.InfiniteRing.html
+//! [`Map::with_options()`]: struct.Map.html#method.with_options
+//! [`MapMut::with_options()`]: struct.MapMut.html#method.with_options
+//! [`MapMut`]: struct.MapMut.html
+//! [`Map`]: struct.Map.html
+//! [`Options`]: struct.Options.html
+//! [`Ring`]: io/struct.Ring.html
+//! [`vmap::io`]: io/index.html
 
 #![deny(missing_docs)]
 
@@ -74,8 +173,6 @@ pub enum Protect {
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Flush {
     /// Request dirty pages to be written immediately and block until completed.
-    ///
-    /// This is not supported on Windows. The flush is always performed asynchronously.
     Sync,
     /// Request dirty pages to be written but do not wait for completion.
     Async,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@
 //! # fs::write(&path, b"this is a test")?;
 //!
 //! // Open with write permissions so the Map can be converted into a MapMut
-//! let map = Map::with_options().write().len(14).open(&path)?;
+//! let (map, file) = Map::with_options().write().len(14).open(&path)?;
 //! assert_eq!(Ok("this is a test"), from_utf8(&map[..]));
 //!
 //! // Move the Map into a MapMut
@@ -541,7 +541,7 @@ mod tests {
     #[test]
     fn read_end() -> Result<()> {
         let (_tmp, path, len) = write_default("read_end")?;
-        let map = Map::with_options().offset(29).open(&path)?;
+        let (map, _) = Map::with_options().offset(29).open(&path)?;
         assert!(map.len() >= 30);
         assert_eq!(len - 29, map.len());
         assert_eq!(Ok("fast and safe memory-mapped IO"), from_utf8(&map[..30]));
@@ -551,7 +551,7 @@ mod tests {
     #[test]
     fn read_min() -> Result<()> {
         let (_tmp, path, len) = write_default("read_min")?;
-        let map = Map::with_options()
+        let (map, _) = Map::with_options()
             .offset(29)
             .len(Extent::Min(30))
             .open(&path)?;
@@ -565,7 +565,7 @@ mod tests {
     #[test]
     fn read_max() -> Result<()> {
         let (_tmp, path, _len) = write_default("read_max")?;
-        let map = Map::with_options()
+        let (map, _) = Map::with_options()
             .offset(29)
             .len(Extent::Max(30))
             .open(&path)?;
@@ -577,7 +577,7 @@ mod tests {
     #[test]
     fn read_exact() -> Result<()> {
         let (_tmp, path, _len) = write_default("read_exact")?;
-        let map = Map::with_options().offset(29).len(30).open(&path)?;
+        let (map, _) = Map::with_options().offset(29).len(30).open(&path)?;
         assert!(map.len() == 30);
         assert_eq!(Ok("fast and safe memory-mapped IO"), from_utf8(&map[..]));
         Ok(())
@@ -586,7 +586,7 @@ mod tests {
     #[test]
     fn copy() -> Result<()> {
         let (_tmp, path, _len) = write_default("copy")?;
-        let mut map = MapMut::with_options()
+        let (mut map, _) = MapMut::with_options()
             .offset(29)
             .len(30)
             .copy()
@@ -605,7 +605,7 @@ mod tests {
         let path: PathBuf = tmp.path().join("write_into_mut");
         fs::write(&path, "this is a test").expect("failed to write file");
 
-        let map = Map::with_options().write().resize(16).open(&path)?;
+        let (map, _) = Map::with_options().write().resize(16).open(&path)?;
         assert_eq!(16, map.len());
         assert_eq!(Ok("this is a test"), from_utf8(&map[..14]));
         assert_eq!(Ok("this is a test\0\0"), from_utf8(&map[..]));
@@ -619,7 +619,7 @@ mod tests {
         assert_eq!(Ok("that is a test"), from_utf8(&map[..14]));
         assert_eq!(Ok("that is a test\0\0"), from_utf8(&map[..]));
 
-        let map = Map::with_options().open(&path)?;
+        let (map, _) = Map::with_options().open(&path)?;
         assert_eq!(16, map.len());
         assert_eq!(Ok("that is a test"), from_utf8(&map[..14]));
         assert_eq!(Ok("that is a test\0\0"), from_utf8(&map[..]));
@@ -633,7 +633,7 @@ mod tests {
         let path: PathBuf = tmp.path().join("truncate");
         fs::write(&path, "this is a test").expect("failed to write file");
 
-        let map = Map::with_options()
+        let (map, _) = Map::with_options()
             .write()
             .truncate(true)
             .resize(16)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,11 @@
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
+#[cfg(feature = "os")]
 pub mod os;
+
+#[cfg(not(feature = "os"))]
+mod os;
 
 mod error;
 pub use self::error::{ConvertResult, Error, Input, Operation, Result};
@@ -52,6 +56,7 @@ pub use self::error::{ConvertResult, Error, Input, Operation, Result};
 mod map;
 pub use self::map::{Map, MapMut, Options};
 
+#[cfg(feature = "io")]
 pub mod io;
 
 /// Protection level for a page.

--- a/src/map.rs
+++ b/src/map.rs
@@ -813,7 +813,6 @@ impl<T: FromPtr> Options<T> {
     /// let first = map1[0];
     ///
     /// map1[0] = b'X';
-    /// map1.flush(&file, vmap::Flush::Sync)?;
     ///
     /// assert_eq!(first, map2[0]);
     /// # Ok(())

--- a/src/map.rs
+++ b/src/map.rs
@@ -1467,7 +1467,7 @@ impl<T: FromPtr> Options<T> {
     pub fn alloc(&self) -> Result<T> {
         let off = Size::page().offset(self.offset);
         let len = match self.len {
-            Extent::End => Size::alloc().round(off) - off,
+            Extent::End => Size::alloc().round(off + 1) - off,
             Extent::Min(l) => Size::alloc().round(off + l) - off,
             Extent::Max(l) | Extent::Exact(l) => l,
         };

--- a/src/os/unix/mach.rs
+++ b/src/os/unix/mach.rs
@@ -131,6 +131,16 @@ pub fn map_ring(len: usize) -> Result<*mut u8> {
 }
 
 /// Unmaps a ring mapping created by `map_ring`.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn unmap_ring(pg: *mut u8, len: usize) -> Result<()> {
     let port = mach_task_self();
     let ret = vm_deallocate(port, pg as vm_address_t, 2 * len);

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -17,15 +17,15 @@ use self::Operation::*;
 // For macOS and iOS we use the mach vm system for rings. The posix module
 // does work correctly on these targets, but it necessitates an otherwise
 // uneeded file descriptor.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(all(feature = "io", any(target_os = "macos", target_os = "ios")))]
 mod mach;
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(all(feature = "io", any(target_os = "macos", target_os = "ios")))]
 pub use self::mach::{map_ring, unmap_ring};
 
 // For non-mach targets load the POSIX version of the ring mapping functions.
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(all(feature = "io", not(any(target_os = "macos", target_os = "ios"))))]
 mod posix;
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(all(feature = "io", not(any(target_os = "macos", target_os = "ios"))))]
 pub use self::posix::{map_ring, unmap_ring};
 
 /// Requests the page size and allocation granularity from the system.

--- a/src/os/unix/mod.rs
+++ b/src/os/unix/mod.rs
@@ -75,6 +75,16 @@ pub fn map_anon(len: usize, prot: Protect) -> Result<*mut u8> {
 }
 
 /// Unmaps a page range from a previos mapping.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn unmap(pg: *mut u8, len: usize) -> Result<()> {
     if munmap(pg as *mut c_void, len) < 0 {
         Err(Error::last_os_error(Unmap))
@@ -84,6 +94,16 @@ pub unsafe fn unmap(pg: *mut u8, len: usize) -> Result<()> {
 }
 
 /// Changes the protection for a page range.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn protect(pg: *mut u8, len: usize, prot: Protect) -> Result<()> {
     let prot = match prot {
         Protect::ReadOnly => PROT_READ,
@@ -98,6 +118,16 @@ pub unsafe fn protect(pg: *mut u8, len: usize, prot: Protect) -> Result<()> {
 }
 
 /// Writes modified whole pages back to the filesystem.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn flush(pg: *mut u8, _file: &File, len: usize, mode: Flush) -> Result<()> {
     let flags = match mode {
         Flush::Sync => MS_SYNC,
@@ -111,6 +141,16 @@ pub unsafe fn flush(pg: *mut u8, _file: &File, len: usize, mode: Flush) -> Resul
 }
 
 /// Updates the advise for the page range.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn advise(
     pg: *mut u8,
     len: usize,
@@ -135,6 +175,16 @@ pub unsafe fn advise(
 }
 
 /// Locks physical pages into memory.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn lock(pg: *mut u8, len: usize) -> Result<()> {
     if mlock(pg as *mut c_void, len) < 0 {
         Err(Error::last_os_error(Lock))
@@ -144,6 +194,16 @@ pub unsafe fn lock(pg: *mut u8, len: usize) -> Result<()> {
 }
 
 /// Unlocks physical pages from memory.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn unlock(pg: *mut u8, len: usize) -> Result<()> {
     if munlock(pg as *mut c_void, len) < 0 {
         Err(Error::last_os_error(Unlock))

--- a/src/os/unix/posix/mod.rs
+++ b/src/os/unix/posix/mod.rs
@@ -74,6 +74,16 @@ fn map(op: Operation, pg: *mut u8, len: usize, flags: c_int, fd: c_int) -> Resul
 }
 
 /// Unmaps a ring mapping created by `map_ring`.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn unmap_ring(pg: *mut u8, len: usize) -> Result<()> {
     unmap(pg, 2 * len)
 }

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -135,6 +135,7 @@ unsafe fn reserve(len: usize) -> Result<*mut c_void> {
     }
 }
 
+#[cfg(feature = "io")]
 unsafe fn map_ring_handle(map: &MapHandle, len: usize, pg: *mut c_void) -> Result<*mut u8> {
     let a = map.view(RingPrimary, FILE_MAP_READ | FILE_MAP_WRITE, 0, len, pg)?;
     let b = map.view(
@@ -157,6 +158,7 @@ unsafe fn map_ring_handle(map: &MapHandle, len: usize, pg: *mut c_void) -> Resul
 /// The length is the size of the sequential range, and the offset of
 /// `len+1` refers to the same memory location at offset `0`. The circle
 /// continues to up through the offset of `2*len - 1`.
+#[cfg(feature = "io")]
 pub fn map_ring(len: usize) -> Result<*mut u8> {
     let full = 2 * len;
     let map = unsafe { MapHandle::new(RingAllocate, INVALID_HANDLE_VALUE, PAGE_READWRITE, full)? };
@@ -182,6 +184,7 @@ pub unsafe fn unmap(pg: *mut u8, _len: usize) -> Result<()> {
 }
 
 /// Unmaps a ring mapping created by `map_ring`.
+#[cfg(feature = "io")]
 pub unsafe fn unmap_ring(pg: *mut u8, len: usize) -> Result<()> {
     if UnmapViewOfFile(pg.offset(len as isize) as *mut c_void) == 0 {
         Err(Error::last_os_error(RingDeallocate))

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -175,6 +175,16 @@ pub fn map_ring(len: usize) -> Result<*mut u8> {
 }
 
 /// Unmaps a page range from a previos mapping.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn unmap(pg: *mut u8, _len: usize) -> Result<()> {
     if UnmapViewOfFile(pg as *mut c_void) != 0 {
         Err(Error::last_os_error(Unmap))
@@ -184,6 +194,16 @@ pub unsafe fn unmap(pg: *mut u8, _len: usize) -> Result<()> {
 }
 
 /// Unmaps a ring mapping created by `map_ring`.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 #[cfg(feature = "io")]
 pub unsafe fn unmap_ring(pg: *mut u8, len: usize) -> Result<()> {
     if UnmapViewOfFile(pg.offset(len as isize) as *mut c_void) == 0 {
@@ -195,6 +215,16 @@ pub unsafe fn unmap_ring(pg: *mut u8, len: usize) -> Result<()> {
 }
 
 /// Changes the protection for a page range.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn protect(pg: *mut u8, len: usize, prot: Protect) -> Result<()> {
     let prot = match prot {
         Protect::ReadOnly => PAGE_READONLY,
@@ -210,6 +240,16 @@ pub unsafe fn protect(pg: *mut u8, len: usize, prot: Protect) -> Result<()> {
 }
 
 /// Writes modified whole pages back to the filesystem.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn flush(pg: *mut u8, file: &File, len: usize, mode: Flush) -> Result<()> {
     if FlushViewOfFile(pg as *mut c_void, len as SIZE_T) == 0 {
         Err(Error::last_os_error(Flush))
@@ -227,6 +267,16 @@ pub unsafe fn flush(pg: *mut u8, file: &File, len: usize, mode: Flush) -> Result
     }
 }
 /// Updates the advise for the page range.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn advise(
     _pg: *mut u8,
     _len: usize,
@@ -237,6 +287,16 @@ pub unsafe fn advise(
 }
 
 /// Locks physical pages into memory.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn lock(pg: *mut u8, len: usize) -> Result<()> {
     if VirtualLock(pg as *mut c_void, len) == 0 {
         Err(Error::last_os_error(Lock))
@@ -246,6 +306,16 @@ pub unsafe fn lock(pg: *mut u8, len: usize) -> Result<()> {
 }
 
 /// Unlocks physical pages from memory.
+///
+/// # Safety
+///
+/// This does not know or care if `pg` or `len` are valid. That is,
+/// it may be null, not at a proper page boundary, point to a size
+/// different from `len`, or worse yet, point to a properly mapped
+/// pointer from some other allocation system.
+///
+/// Generally don't use this unless you are entirely sure you are
+/// doing so correctly.
 pub unsafe fn unlock(pg: *mut u8, len: usize) -> Result<()> {
     if VirtualUnlock(pg as *mut c_void, len) == 0 {
         Err(Error::last_os_error(Unlock))


### PR DESCRIPTION
This carries on with some updates from the 0.4 release. Mostly this adds some more documentation along with a few updates and features.

## Additions

* More documentation!
* A `.flush_range()` method on `MapMut`
* Cargo features to disable the `io` and `os` modules.
* Update to the `.open()` method in `Options` to return the `File` object.

## Fixes

* Documentation corrections.
* Ensure a non-zero size is always selected for all `.alloc()` values in `Options`.
