### PR TITLE
Extend platform support

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -53,3 +53,50 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+
+  test_android:
+    name: Test Android
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install Cross
+        run: |
+          CROSS_URL=https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-gnu.tar.gz
+          mkdir -p "$HOME/.bin"
+          curl -sfSL --retry-delay 10 --retry 5 "${CROSS_URL}" | tar zxf - -C "$HOME/.bin"
+          echo "$HOME/.bin" >> $GITHUB_PATH
+      - name: Run cross test
+        run: cross test --target aarch64-linux-android
+
+  build_misc:
+    name: Build miscellaneous systems
+    strategy:
+      matrix:
+        target:
+          - x86_64-sun-solaris
+          - x86_64-unknown-netbsd
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Install Cross
+        run: |
+          CROSS_URL=https://github.com/rust-embedded/cross/releases/download/v0.2.1/cross-v0.2.1-x86_64-unknown-linux-gnu.tar.gz
+          mkdir -p "$HOME/.bin"
+          curl -sfSL --retry-delay 10 --retry 5 "${CROSS_URL}" | tar zxf - -C "$HOME/.bin"
+          echo "$HOME/.bin" >> $GITHUB_PATH
+      - name: Run cross build
+        run: cross build --target ${{ matrix.target }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,4 +1,4 @@
-on: [push]
+on: [push, pull_request]
 
 name: Verify
 

--- a/src/os/unix/posix/memfd.rs
+++ b/src/os/unix/posix/memfd.rs
@@ -20,35 +20,42 @@ pub fn memfd_open() -> Result<c_int> {
     }
 }
 
-#[cfg(not(any(target_os = "linux", target_os = "android")))]
+#[cfg(target_os = "freebsd")]
 pub fn memfd_open() -> Result<c_int> {
+    let fd = unsafe { libc::shm_open(libc::SHM_ANON, libc::O_RDWR, 0o600) };
+    if fd < 0 {
+        Err(Error::last_os_error(Operation::MemoryFd))
+    } else {
+        Ok(fd as c_int)
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd")))]
+pub fn memfd_open() -> Result<c_int> {
+    use libc::c_char;
     use rand::distributions::Alphanumeric;
     use rand::{thread_rng, Rng};
 
     const OFLAGS: c_int = libc::O_RDWR | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC;
 
-    // There *must* be a better way to do this...
-    let mut path: [i8; 18] = [
-        0x2f, 0x74, 0x6d, 0x70, 0x2f, 0x76, 0x6d, 0x61, 0x70, 0x2d, // "/tmp/vmap-"
-        0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x58, 0x00, // "XXXXXXX\0"
-    ];
+    let mut path: [u8; 18] = *b"/tmp/vmap-XXXXXXX\0";
 
     let mut rng = thread_rng();
     let end = path.len() - 1;
 
     loop {
         for dst in &mut path[10..end] {
-            *dst = rng.sample(&Alphanumeric) as i8;
+            *dst = rng.sample(&Alphanumeric) as u8;
         }
 
-        let fd = unsafe { libc::shm_open(path.as_ptr(), OFLAGS, 0600) };
+        let fd = unsafe { libc::shm_open(path.as_ptr() as *const c_char, OFLAGS, 0o600) };
         if fd < 0 {
             let err = Error::last_os_error(Operation::MemoryFd);
             if err.raw_os_error() != Some(libc::EEXIST) {
                 return Err(err);
             }
         } else {
-            unsafe { libc::shm_unlink(path.as_ptr()) };
+            unsafe { libc::shm_unlink(path.as_ptr() as *const c_char) };
             return Ok(fd);
         }
     }


### PR DESCRIPTION
This fixes a few issues:
* octal modes specified incorrectly
* assumption that `c_char` is `i8` (it's `u8` on some platforms, it seems)
* adds freebsd-specific memfd implementation

Great crate by the way!