### PR TITLE
Add volatile and unaligned reads and writes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@
 
 use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::{mem, ptr};
 
 #[cfg(feature = "os")]
 pub mod os;
@@ -507,6 +508,25 @@ pub trait Span: Deref<Target = [u8]> + Sized + sealed::Span {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Performs a volatile read of the value at a given offset.
+    ///
+    /// Volatile operations are intended to act on I/O memory, and are
+    /// guaranteed to not be elided or reordered by the compiler across
+    /// other volatile operations.
+    #[inline]
+    fn read_volatile<T: sealed::Scalar>(&self, offset: usize) -> T {
+        assert_capacity::<T>(offset, self.len());
+        assert_alignment::<T>(offset, self.as_ptr());
+        unsafe { ptr::read_volatile(self.as_ptr().add(offset) as *const T) }
+    }
+
+    /// Performs an unaligned read of the value at a given offset.
+    #[inline]
+    fn read_unaligned<T: sealed::Scalar>(&self, offset: usize) -> T {
+        assert_capacity::<T>(offset, self.len());
+        unsafe { ptr::read_unaligned(self.as_ptr().add(offset) as *const T) }
+    }
 }
 
 /// General trait for working with any memory-safe representation of a
@@ -514,6 +534,25 @@ pub trait Span: Deref<Target = [u8]> + Sized + sealed::Span {
 pub trait SpanMut: Span + DerefMut {
     /// Get a mutable pointer to the start of the allocated region.
     fn as_mut_ptr(&mut self) -> *mut u8;
+
+    /// Performs a volatile write of the value at a given offset.
+    ///
+    /// Volatile operations are intended to act on I/O memory, and are
+    /// guaranteed to not be elided or reordered by the compiler across
+    /// other volatile operations.
+    #[inline]
+    fn write_volatile<T: sealed::Scalar>(&mut self, offset: usize, value: T) {
+        assert_capacity::<T>(offset, self.len());
+        assert_alignment::<T>(offset, self.as_ptr());
+        unsafe { ptr::write_volatile(self.as_mut_ptr().add(offset) as *mut T, value) }
+    }
+
+    /// Performs an unaligned write of the value at a given offset.
+    #[inline]
+    fn write_unaligned<T: sealed::Scalar>(&mut self, offset: usize, value: T) {
+        assert_capacity::<T>(offset, self.len());
+        unsafe { ptr::write_unaligned(self.as_mut_ptr().add(offset) as *mut T, value) }
+    }
 }
 
 impl<'a> Span for &'a [u8] {
@@ -557,6 +596,46 @@ mod sealed {
 
     pub trait FromPtr {
         unsafe fn from_ptr(ptr: *mut u8, len: usize) -> Self;
+    }
+
+    pub trait Scalar: Default {}
+
+    impl Scalar for u8 {}
+    impl Scalar for i8 {}
+    impl Scalar for u16 {}
+    impl Scalar for i16 {}
+    impl Scalar for u32 {}
+    impl Scalar for i32 {}
+    impl Scalar for u64 {}
+    impl Scalar for i64 {}
+    impl Scalar for u128 {}
+    impl Scalar for i128 {}
+    impl Scalar for usize {}
+    impl Scalar for isize {}
+    impl Scalar for f32 {}
+    impl Scalar for f64 {}
+}
+
+#[inline]
+fn assert_alignment<T>(offset: usize, ptr: *const u8) {
+    if unsafe { ptr.add(offset) } as usize % mem::align_of::<T>() != 0 {
+        panic!(
+            "offset improperly aligned: the requirement is {} but the offset is +{}/-{}",
+            mem::align_of::<T>(),
+            ptr as usize % mem::align_of::<T>(),
+            mem::align_of::<T>() - (ptr as usize % mem::align_of::<T>()),
+        )
+    }
+}
+
+#[inline]
+fn assert_capacity<T>(offset: usize, len: usize) {
+    if offset + mem::size_of::<T>() > len {
+        panic!(
+            "index out of bounds: the len is {} but the index is {}",
+            len,
+            offset + mem::size_of::<T>()
+        )
     }
 }
 

--- a/src/os/windows.rs
+++ b/src/os/windows.rs
@@ -34,7 +34,7 @@ impl MapHandle {
             file,
             ptr::null_mut(),
             prot,
-            (len >> 32) as DWORD,
+            (len >> 16 >> 16) as DWORD,
             (len & 0xffffffff) as DWORD,
             ptr::null(),
         );
@@ -55,7 +55,7 @@ impl MapHandle {
         MapViewOfFileEx(
             self.map,
             access as DWORD,
-            (off >> 32) as DWORD,
+            (off >> 16 >> 16) as DWORD,
             (off & 0xffffffff) as DWORD,
             len as SIZE_T,
             at,


### PR DESCRIPTION
This adds volatile and unaligned reads and write methods to `Span` and `SpanMut`. These a light wrappers arounds the intrinsic rust functions, but these can guarantee the safety of memory access.