### PR TITLE
Fix path translation. Remove rand dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,6 @@ system_error = "0.1.1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-[target.'cfg(all(unix, not(any(target_os = "linux", target_os = "android", target_os = "macos", target_os = "ios"))))'.dependencies]
-rand = "0.7"
-
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["std", "basetsd", "minwindef", "sysinfoapi", "handleapi", "memoryapi", "fileapi"] }
 

--- a/src/os/unix/posix/memfd.rs
+++ b/src/os/unix/posix/memfd.rs
@@ -32,31 +32,26 @@ pub fn memfd_open() -> Result<c_int> {
 
 #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "freebsd")))]
 pub fn memfd_open() -> Result<c_int> {
-    use libc::c_char;
-    use rand::distributions::Alphanumeric;
-    use rand::{thread_rng, Rng};
-
     const OFLAGS: c_int = libc::O_RDWR | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC;
+    let mut path_bytes: [u8; 14] = *b"/vmap-XXXXXXX\0";
 
-    let mut path: [u8; 18] = *b"/tmp/vmap-XXXXXXX\0";
+    for i in (0..10000000).cycle() {
+        let path = {
+            use std::io::Write;
+            write!(&mut path_bytes[6..], "{:0>7}", i).unwrap();
+            std::ffi::CStr::from_bytes_with_nul(&path_bytes).unwrap()
+        };
 
-    let mut rng = thread_rng();
-    let end = path.len() - 1;
-
-    loop {
-        for dst in &mut path[10..end] {
-            *dst = rng.sample(&Alphanumeric) as u8;
-        }
-
-        let fd = unsafe { libc::shm_open(path.as_ptr() as *const c_char, OFLAGS, 0o600) };
+        let fd = unsafe { libc::shm_open(path.as_ptr(), OFLAGS, 0o600) };
         if fd < 0 {
             let err = Error::last_os_error(Operation::MemoryFd);
             if err.raw_os_error() != Some(libc::EEXIST) {
                 return Err(err);
             }
         } else {
-            unsafe { libc::shm_unlink(path.as_ptr() as *const c_char) };
+            unsafe { libc::shm_unlink(path.as_ptr()) };
             return Ok(fd);
         }
     }
+    unreachable!();
 }


### PR DESCRIPTION
On some (most?) POSIX platforms, `shm_open` does path translation (for example, `/foo` might open `/tmp/foo`).  On some BSDs, for example, this path must only have a leading slash and no other slashes, so this change makes the path more universally supported.

To remove `rand`, I repeatedly count from 0 to 9999999 and use that (formatted to a string) as the path suffix.  This is probably worse if lots of contention occurs, but I'm guessing about the same or faster if there is no contention.

Closes #16.