### PR TITLE
Remove depreciated code and update to 2021

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2021-12-24
+- Remove deprecated code
+- Update to 2021 rust edition
+
 ## [0.4.4] - 2021-02-20
 
 ### Changed
@@ -32,7 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stopped using deprecated examples where possible
 - Return the `File` object when `open`ing from a path
 
-[Unreleased]: https://github.com/kalamay/vmap-rs/compare/v0.4.4...HEAD
+[Unreleased]: https://github.com/kalamay/vmap-rs/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/kalamay/vmap-rs/compare/v0.4.4...v0.5.0
 [0.4.4]: https://github.com/kalamay/vmap-rs/compare/v0.4.3...v0.4.4
 [0.4.3]: https://github.com/kalamay/vmap-rs/compare/v0.4.2...v0.4.3
 [0.4.2]: https://github.com/kalamay/vmap-rs/compare/v0.4.1...v0.4.2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/kalamay/vmap-rs"
 documentation = "https://docs.rs/vmap"
 description = "Cross-platform library for fast and safe memory-mapped IO"
 keywords = ["mmap", "io", "file", "circular-buffer", "ring-buffer"]
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["all"]
@@ -19,10 +19,10 @@ os = []
 system_error = "0.1.1"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = "0.2.109"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["std", "basetsd", "minwindef", "sysinfoapi", "handleapi", "memoryapi", "fileapi"] }
+winapi = { version = "0.3.9", features = ["std", "basetsd", "minwindef", "sysinfoapi", "handleapi", "memoryapi", "fileapi"] }
 
 [dev-dependencies]
-tempdir = "0.3"
+tempdir = "0.3.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmap"
-version = "0.4.4"
+version = "0.5.0"
 authors = ["Jeremy Larkin <jeremylarkin@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/kalamay/vmap-rs"
@@ -16,13 +16,13 @@ io = []
 os = []
 
 [dependencies]
-system_error = "0.1.1"
+system_error = "0.1"
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.109"
+libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.9", features = ["std", "basetsd", "minwindef", "sysinfoapi", "handleapi", "memoryapi", "fileapi"] }
+winapi = { version = "0.3", features = ["std", "basetsd", "minwindef", "sysinfoapi", "handleapi", "memoryapi", "fileapi"] }
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempdir = "0.3"

--- a/README.md
+++ b/README.md
@@ -118,17 +118,17 @@ assert_eq!(line, "this is test line 2\n");
 write!(&mut buf, "this is test line {}\n", i)?;
 ```
 
-[`.flush()`]: https://docs.rs/vmap/0.4.4/vmap/struct.MapMut.html#method.flush
-[`.into_map()`]: https://docs.rs/vmap/0.4.4/vmap/struct.MapMut.html#method.into_map
-[`.into_map_mut()`]: https://docs.rs/vmap/0.4.4/vmap/struct.Map.html#method.into_map_mut
-[`BufReader`]: https://docs.rs/vmap/0.4.4/vmap/io/struct.BufReader.html
-[`BufWriter`]: https://docs.rs/vmap/0.4.4/vmap/io/struct.BufWriter.html
-[`InfiniteRing`]: https://docs.rs/vmap/0.4.4/vmap/io/struct.InfiniteRing.html
-[`Map::with_options()`]: https://docs.rs/vmap/0.4.4/vmap/struct.Map.html#method.with_options
-[`MapMut::with_options()`]: https://docs.rs/vmap/0.4.4/vmap/struct.MapMut.html#method.with_options
-[`MapMut`]: https://docs.rs/vmap/0.4.4/vmap/struct.MapMut.html
-[`Map`]: https://docs.rs/vmap/0.4.4/vmap/struct.Map.html
-[`Options`]: https://docs.rs/vmap/0.4.4/vmap/struct.Options.html
-[`Ring`]: https://docs.rs/vmap/0.4.4/vmap/io/struct.Ring.html
-[`vmap::io`]: https://docs.rs/vmap/0.4.4/vmap/io/index.html
+[`.flush()`]: https://docs.rs/vmap/0.5.0/vmap/struct.MapMut.html#method.flush
+[`.into_map()`]: https://docs.rs/vmap/0.5.0/vmap/struct.MapMut.html#method.into_map
+[`.into_map_mut()`]: https://docs.rs/vmap/0.5.0/vmap/struct.Map.html#method.into_map_mut
+[`BufReader`]: https://docs.rs/vmap/0.5.0/vmap/io/struct.BufReader.html
+[`BufWriter`]: https://docs.rs/vmap/0.5.0/vmap/io/struct.BufWriter.html
+[`InfiniteRing`]: https://docs.rs/vmap/0.5.0/vmap/io/struct.InfiniteRing.html
+[`Map::with_options()`]: https://docs.rs/vmap/0.5.0/vmap/struct.Map.html#method.with_options
+[`MapMut::with_options()`]: https://docs.rs/vmap/0.5.0/vmap/struct.MapMut.html#method.with_options
+[`MapMut`]: https://docs.rs/vmap/0.5.0/vmap/struct.MapMut.html
+[`Map`]: https://docs.rs/vmap/0.5.0/vmap/struct.Map.html
+[`Options`]: https://docs.rs/vmap/0.5.0/vmap/struct.Options.html
+[`Ring`]: https://docs.rs/vmap/0.5.0/vmap/io/struct.Ring.html
+[`vmap::io`]: https://docs.rs/vmap/0.5.0/vmap/io/index.html
 [`vmap`]: https://docs.rs/vmap/

--- a/src/io/buffer.rs
+++ b/src/io/buffer.rs
@@ -69,7 +69,7 @@ impl<R: Read> BufReader<R> {
 
     /// Returns a reference to the internally buffered data.
     pub fn buffer(&self) -> &[u8] {
-        &self.buf.as_read_slice(std::usize::MAX)
+        self.buf.as_read_slice(std::usize::MAX)
     }
 
     /// Unwraps this `BufReader`, returning the underlying reader.
@@ -155,7 +155,7 @@ impl<W: Write> BufWriter<W> {
 
     /// Gets a reference to the underlying writer.
     pub fn get_ref(&self) -> &W {
-        &self.inner.as_ref().unwrap()
+        self.inner.as_ref().unwrap()
     }
 
     /// Gets a mutable reference to the underlying writer.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,27 +288,6 @@ fn load_system_info() -> (u32, u32) {
 /// # Examples
 ///
 /// ```
-/// let size = vmap::AllocSize::new();
-/// let pages = size.count(200);
-/// assert_eq!(pages, 1);
-///
-/// let round = size.round(200);
-/// println!("200 bytes requires a {} byte mapping", round);
-///
-/// let count = size.count(10000);
-/// println!("10000 bytes requires {} pages", count);
-///
-/// let size = size.size(3);
-/// println!("3 pages are {} bytes", size);
-/// ```
-#[deprecated(since = "0.4.0", note = "use Size instead")]
-pub type AllocSize = Size;
-
-/// Type for calculation system page or allocation size information.
-///
-/// # Examples
-///
-/// ```
 /// let size = vmap::Size::alloc();
 /// let pages = size.count(200);
 /// assert_eq!(pages, 1);
@@ -326,16 +305,6 @@ pub type AllocSize = Size;
 pub struct Size(usize);
 
 impl Size {
-    /// Creates a type for calculating allocation numbers and byte offsets.
-    ///
-    /// The size is determined from the system's configurated allocation
-    /// granularity. This value is cached making it very cheap to construct.
-    #[inline]
-    #[deprecated(since = "0.4.0", note = "use Size::alloc() instead")]
-    pub fn new() -> Self {
-        Self::alloc()
-    }
-
     /// Creates a type for calculating page numbers and byte offsets.
     ///
     /// The size is determined from the system's configurated page size.

--- a/src/map.rs
+++ b/src/map.rs
@@ -1,10 +1,9 @@
 use std::convert::TryFrom;
 use std::fs::{File, OpenOptions};
-use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 use std::path::Path;
 use std::slice;
-use std::{cmp, fmt, io};
+use std::{cmp, fmt, io, marker};
 
 use crate::os::{advise, flush, lock, map_anon, map_file, protect, unlock, unmap};
 use crate::sealed::FromPtr;
@@ -510,7 +509,7 @@ pub struct Options<T: FromPtr> {
     offset: usize,
     protect: Protect,
     truncate: bool,
-    phantom: PhantomData<T>,
+    _marker: marker::PhantomData<fn() -> T>,
 }
 
 impl<T: FromPtr> Options<T> {
@@ -532,7 +531,7 @@ impl<T: FromPtr> Options<T> {
             offset: 0,
             protect: Protect::ReadOnly,
             truncate: false,
-            phantom: PhantomData,
+            _marker: marker::PhantomData,
         }
     }
 


### PR DESCRIPTION
Update to use 2021 rust edition and remove deprecated code. This has been updated to release version `0.5.0`.