### PR TITLE
Allow converting to an io error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2024-03-07
+- Add error conversion
+
 ## [0.6.0] - 2024-03-06
 - Update page advice
 - Reduce unsafe areas [@peamaeq](https://github.com/peamaeq)
@@ -43,7 +46,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stopped using deprecated examples where possible
 - Return the `File` object when `open`ing from a path
 
-[Unreleased]: https://github.com/kalamay/vmap-rs/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/kalamay/vmap-rs/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/kalamay/vmap-rs/compare/v0.6.0...v0.6.1
 [0.6.0]: https://github.com/kalamay/vmap-rs/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/kalamay/vmap-rs/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/kalamay/vmap-rs/compare/v0.4.4...v0.5.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vmap"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Jeremy Larkin <jeremylarkin@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/kalamay/vmap-rs"

--- a/README.md
+++ b/README.md
@@ -118,17 +118,17 @@ assert_eq!(line, "this is test line 2\n");
 write!(&mut buf, "this is test line {}\n", i)?;
 ```
 
-[`.flush()`]: https://docs.rs/vmap/0.6.0/vmap/struct.MapMut.html#method.flush
-[`.into_map()`]: https://docs.rs/vmap/0.6.0/vmap/struct.MapMut.html#method.into_map
-[`.into_map_mut()`]: https://docs.rs/vmap/0.6.0/vmap/struct.Map.html#method.into_map_mut
-[`BufReader`]: https://docs.rs/vmap/0.6.0/vmap/io/struct.BufReader.html
-[`BufWriter`]: https://docs.rs/vmap/0.6.0/vmap/io/struct.BufWriter.html
-[`InfiniteRing`]: https://docs.rs/vmap/0.6.0/vmap/io/struct.InfiniteRing.html
-[`Map::with_options()`]: https://docs.rs/vmap/0.6.0/vmap/struct.Map.html#method.with_options
-[`MapMut::with_options()`]: https://docs.rs/vmap/0.6.0/vmap/struct.MapMut.html#method.with_options
-[`MapMut`]: https://docs.rs/vmap/0.6.0/vmap/struct.MapMut.html
-[`Map`]: https://docs.rs/vmap/0.6.0/vmap/struct.Map.html
-[`Options`]: https://docs.rs/vmap/0.6.0/vmap/struct.Options.html
-[`Ring`]: https://docs.rs/vmap/0.6.0/vmap/io/struct.Ring.html
-[`vmap::io`]: https://docs.rs/vmap/0.6.0/vmap/io/index.html
+[`.flush()`]: https://docs.rs/vmap/0.6.1/vmap/struct.MapMut.html#method.flush
+[`.into_map()`]: https://docs.rs/vmap/0.6.1/vmap/struct.MapMut.html#method.into_map
+[`.into_map_mut()`]: https://docs.rs/vmap/0.6.1/vmap/struct.Map.html#method.into_map_mut
+[`BufReader`]: https://docs.rs/vmap/0.6.1/vmap/io/struct.BufReader.html
+[`BufWriter`]: https://docs.rs/vmap/0.6.1/vmap/io/struct.BufWriter.html
+[`InfiniteRing`]: https://docs.rs/vmap/0.6.1/vmap/io/struct.InfiniteRing.html
+[`Map::with_options()`]: https://docs.rs/vmap/0.6.1/vmap/struct.Map.html#method.with_options
+[`MapMut::with_options()`]: https://docs.rs/vmap/0.6.1/vmap/struct.MapMut.html#method.with_options
+[`MapMut`]: https://docs.rs/vmap/0.6.1/vmap/struct.MapMut.html
+[`Map`]: https://docs.rs/vmap/0.6.1/vmap/struct.Map.html
+[`Options`]: https://docs.rs/vmap/0.6.1/vmap/struct.Options.html
+[`Ring`]: https://docs.rs/vmap/0.6.1/vmap/io/struct.Ring.html
+[`vmap::io`]: https://docs.rs/vmap/0.6.1/vmap/io/index.html
 [`vmap`]: https://docs.rs/vmap/


### PR DESCRIPTION
This update implements `From<std::io::Eror>` for `vamp::Error`.