### PR TITLE
Update traits

### DIFF
--- a/src/io/buffer.rs
+++ b/src/io/buffer.rs
@@ -9,9 +9,8 @@ use std::{
 
 /// The `BufReader` adds buffering to any reader using a specialized buffer.
 ///
-/// This is very similar `std::io::BufReader`, but it uses a
-/// [`Ring`](struct.Ring.html) for the internal buffer, and it provides a
-/// configurable low water mark.
+/// This is very similar `std::io::BufReader`, but it uses a [`Ring`] for the
+/// internal buffer, and it provides a configurable low water mark.
 ///
 /// # Examples
 ///
@@ -49,29 +48,46 @@ impl<R: Read> BufReader<R> {
     }
 
     /// Get the low-water level.
+    #[inline]
     pub fn lowat(&self) -> usize {
         self.lowat
     }
 
     /// Set the low-water level.
     ///
-    /// When the internal buffer content length drops to this level, a
-    /// subsequent read will request more from the inner reader.
+    /// When the internal buffer content length drops to this level or below, a
+    /// subsequent call to `fill_buffer()` will request more from the inner reader.
+    ///
+    /// If it desired for `fill_buffer()` to always request a `read()`, you
+    /// may use:
+    ///
+    /// ```
+    /// # use vmap::io::BufReader;
+    /// # fn main() -> std::io::Result<()> {
+    /// let mut buf = BufReader::new(std::io::stdin(), 4096)?;
+    /// buf.set_lowat(usize::MAX);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
     pub fn set_lowat(&mut self, val: usize) {
         self.lowat = val
     }
 
     /// Gets a reference to the underlying reader.
+    #[inline]
     pub fn get_ref(&self) -> &R {
         &self.inner
     }
 
     /// Gets a mutable reference to the underlying reader.
+    #[inline]
     pub fn get_mut(&mut self) -> &mut R {
         &mut self.inner
     }
 
     /// Returns a reference to the internally buffered data.
+    #[inline]
     pub fn buffer(&self) -> &[u8] {
         self.buf.as_read_slice(std::usize::MAX)
     }
@@ -150,8 +166,8 @@ impl<R: Read> BufRead for BufReader<R> {
 
 /// The `BufWriter` adds buffering to any writer using a specialized buffer.
 ///
-/// This is very similar `std::io::BufWriter`, but it uses a
-/// [`Ring`](struct.Ring.html) for internal the buffer.
+/// This is very similar `std::io::BufWriter`, but it uses a [`Ring`] for the
+/// internal the buffer.
 ///
 /// # Examples
 ///

--- a/src/io/buffer.rs
+++ b/src/io/buffer.rs
@@ -150,6 +150,33 @@ impl<R: Read> Read for BufReader<R> {
     }
 }
 
+impl<R: Read + Write> Write for BufReader<R> {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.inner.write(buf)
+    }
+
+    #[inline]
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        self.inner.write_vectored(bufs)
+    }
+
+    #[inline]
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        self.inner.write_all(buf)
+    }
+
+    #[inline]
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        self.inner.write_fmt(fmt)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
 impl<R: Read> BufRead for BufReader<R> {
     fn fill_buf(&mut self) -> io::Result<&[u8]> {
         if self.buf.read_len() <= self.lowat {
@@ -195,72 +222,198 @@ impl<R: Read> BufRead for BufReader<R> {
 /// ```
 pub struct BufWriter<W: Write> {
     buf: Ring,
-    inner: Option<W>,
+    inner: W,
     panicked: bool,
 }
 
 impl<W: Write> BufWriter<W> {
     /// Creates a new `BufWriter`.
     pub fn new(inner: W, capacity: usize) -> Result<Self> {
-        Ok(Self {
-            buf: Ring::new(capacity)?,
-            inner: Some(inner),
+        Ok(Self::from_parts(inner, Ring::new(capacity)?))
+    }
+
+    /// Creates a new `BufWriter` using an allocated, and possibly populated,
+    /// [`Ring`] instance. Consider calling [`Ring::clear()`] prior if the
+    /// contents of the ring should be discarded.
+    pub fn from_parts(inner: W, buf: Ring) -> Self {
+        Self {
+            buf,
+            inner,
             panicked: false,
-        })
+        }
     }
 
     /// Gets a reference to the underlying writer.
+    #[inline]
     pub fn get_ref(&self) -> &W {
-        self.inner.as_ref().unwrap()
+        &self.inner
     }
 
     /// Gets a mutable reference to the underlying writer.
+    #[inline]
     pub fn get_mut(&mut self) -> &mut W {
-        self.inner.as_mut().unwrap()
+        &mut self.inner
     }
 
     /// Unwraps this `BufWriter`, returning the underlying writer.
-    pub fn into_inner(mut self) -> io::Result<W> {
-        self.flush_buf()?;
-        Ok(self.inner.take().unwrap())
+    ///
+    /// On `Err`, the result is a tuple combining the error that occurred while
+    /// flusing the buffer, and the buffer object.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::io::{self, Write, ErrorKind};
+    /// use vmap::io::BufWriter;
+    ///
+    /// struct ErringWriter(usize);
+    /// impl Write for ErringWriter {
+    ///   fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    ///     // eventually fails with BrokenPipe
+    /// #   match self.0.min(buf.len()) {
+    /// #     0 => Err(ErrorKind::BrokenPipe.into()),
+    /// #     n => { self.0 -= n; Ok(n) },
+    /// #   }
+    ///   }
+    ///   fn flush(&mut self) -> io::Result<()> { Ok(()) }
+    /// }
+    ///
+    /// # fn main() -> vmap::Result<()> {
+    /// let mut stream = BufWriter::new(ErringWriter(6), 4096)?;
+    /// stream.write_all(b"hello\nworld\n")?;
+    ///
+    /// // flush the buffer and get the original stream back
+    /// let stream = match stream.into_inner() {
+    ///     Ok(s) => s,
+    ///     Err(e) => {
+    ///         assert_eq!(e.error().kind(), ErrorKind::BrokenPipe);
+    ///
+    ///         // You can forcefully obtain the stream, however it is in an
+    ///         // failing state.
+    ///         let (recovered_writer, ring) = e.into_inner().into_parts();
+    ///         assert_eq!(ring.unwrap().as_ref(), b"world\n");
+    ///         recovered_writer
+    ///     }
+    /// };
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn into_inner(mut self) -> std::result::Result<W, IntoInnerError<W>> {
+        match self.flush_buf() {
+            Err(e) => Err(IntoInnerError(self, e)),
+            Ok(()) => Ok(self.into_parts().0),
+        }
+    }
+
+    /// Disassembles this [`BufWriter`] into the underlying writer and the [`Ring`]
+    /// used for buffering, containing any buffered but unwritted data.
+    ///
+    /// If the underlying writer panicked during the previous write, the [`Ring`]
+    /// will be wrapped in a [`WriterPanicked`] error. In this case, the content
+    /// still buffered within the [`Ring`] may or may not have been written.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::io::{self, Write};
+    /// use std::panic::{catch_unwind, AssertUnwindSafe};
+    /// use vmap::io::BufWriter;
+    ///
+    /// struct PanickingWriter;
+    /// impl Write for PanickingWriter {
+    ///   fn write(&mut self, buf: &[u8]) -> io::Result<usize> { panic!() }
+    ///   fn flush(&mut self) -> io::Result<()> { panic!() }
+    /// }
+    ///
+    /// # fn main() -> vmap::Result<()> {
+    /// let mut stream = BufWriter::new(PanickingWriter, 4096)?;
+    /// stream.write_all(b"testing")?;
+    /// let result = catch_unwind(AssertUnwindSafe(|| {
+    ///     stream.flush().unwrap()
+    /// }));
+    /// assert!(result.is_err());
+    /// let (recovered_writer, ring) = stream.into_parts();
+    /// assert!(matches!(recovered_writer, PanickingWriter));
+    /// assert_eq!(ring.unwrap_err().into_inner().as_ref(), b"testing");
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn into_parts(self) -> (W, std::result::Result<Ring, WriterPanicked>) {
+        // SAFETY: forget(self) prevents double dropping inner and buf.
+        let inner = unsafe { std::ptr::read(&self.inner) };
+        let buf = unsafe { std::ptr::read(&self.buf) };
+        let buf = if self.panicked {
+            Err(WriterPanicked(buf))
+        } else {
+            Ok(buf)
+        };
+
+        std::mem::forget(self);
+
+        (inner, buf)
     }
 
     fn flush_buf(&mut self) -> io::Result<()> {
-        let mut written = 0;
-        let len = self.buf.read_len();
-        let mut ret = Ok(());
-        while written < len {
+        loop {
+            if self.buf.is_empty() {
+                break Ok(());
+            }
+
             self.panicked = true;
-            let r = self
-                .inner
-                .as_mut()
-                .unwrap()
-                .write(self.buf.as_read_slice(std::usize::MAX));
+            let r = self.inner.write(self.buf.as_read_slice(std::usize::MAX));
             self.panicked = false;
 
             match r {
                 Ok(0) => {
-                    ret = Err(ErrorKind::WriteZero.into());
-                    break;
+                    break Err(ErrorKind::WriteZero.into());
                 }
-                Ok(n) => written += n,
+                Ok(n) => self.buf.consume(n),
                 Err(ref e) if e.kind() == ErrorKind::Interrupted => {}
-                Err(e) => {
-                    ret = Err(e);
-                    break;
-                }
+                Err(e) => break Err(e),
             }
         }
-        if written > 0 {
-            self.buf.consume(written);
-        }
-        ret
+    }
+}
+
+impl<W: Write> Deref for BufWriter<W> {
+    type Target = W;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.get_ref()
+    }
+}
+
+impl<W: Write> DerefMut for BufWriter<W> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.get_mut()
+    }
+}
+
+impl<W> AsRef<W> for BufWriter<W>
+where
+    W: Write,
+    <BufWriter<W> as Deref>::Target: AsRef<W>,
+{
+    fn as_ref(&self) -> &W {
+        self.deref()
+    }
+}
+
+impl<W> AsMut<W> for BufWriter<W>
+where
+    W: Write,
+    <BufWriter<W> as Deref>::Target: AsMut<W>,
+{
+    fn as_mut(&mut self) -> &mut W {
+        self.deref_mut()
     }
 }
 
 impl<W: Write> Drop for BufWriter<W> {
     fn drop(&mut self) {
-        if self.inner.is_some() && !self.panicked {
+        if !self.panicked {
             let _r = self.flush_buf();
         }
     }
@@ -273,7 +426,7 @@ impl<W: Write> Write for BufWriter<W> {
         }
         if buf.len() >= self.buf.write_len() {
             self.panicked = true;
-            let r = self.inner.as_mut().unwrap().write(buf);
+            let r = self.inner.write(buf);
             self.panicked = false;
             r
         } else {
@@ -283,5 +436,94 @@ impl<W: Write> Write for BufWriter<W> {
 
     fn flush(&mut self) -> io::Result<()> {
         self.flush_buf().and_then(|()| self.get_mut().flush())
+    }
+}
+
+impl<W: Write + Read> Read for BufWriter<W> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+
+    #[inline]
+    fn read_vectored(&mut self, bufs: &mut [io::IoSliceMut<'_>]) -> io::Result<usize> {
+        self.inner.read_vectored(bufs)
+    }
+
+    #[inline]
+    fn read_to_end(&mut self, buf: &mut Vec<u8>) -> io::Result<usize> {
+        self.inner.read_to_end(buf)
+    }
+
+    #[inline]
+    fn read_to_string(&mut self, buf: &mut String) -> io::Result<usize> {
+        self.inner.read_to_string(buf)
+    }
+
+    #[inline]
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.inner.read_exact(buf)
+    }
+}
+
+/// An error returned by [`BufWriter::into_inner`] which combines an error that
+/// happened while writing out the buffer, and the buffered writer object
+/// which may be used to recover from the condition.
+pub struct IntoInnerError<W: Write>(BufWriter<W>, io::Error);
+
+impl<W: Write> IntoInnerError<W> {
+    /// Returns the error which caused the call to [`BufWriter::into_inner()`]
+    /// to fail.
+    pub fn error(&self) -> &io::Error {
+        &self.1
+    }
+
+    /// Consumes the [`IntoInnerError`] and returns the buffered writer which
+    /// received the error.
+    pub fn into_inner(self) -> BufWriter<W> {
+        self.0
+    }
+
+    /// Consumes the [`IntoInnerError`] and returns the error which caused the call to
+    /// [`BufWriter::into_inner()`] to fail. Unlike `error`, this can be used to
+    /// obtain ownership of the underlying error.
+    pub fn into_error(self) -> io::Error {
+        self.1
+    }
+
+    /// Consumes the [`IntoInnerError`] and returns the error which caused the call to
+    /// [`BufWriter::into_inner()`] to fail, and the underlying writer.
+    pub fn into_parts(self) -> (io::Error, BufWriter<W>) {
+        (self.1, self.0)
+    }
+}
+
+/// Error returned for the buffered data from `BufWriter::into_parts` when the underlying
+/// writer has previously panicked. The contents of the buffer may be partially written.
+pub struct WriterPanicked(Ring);
+
+impl WriterPanicked {
+    /// Returns the [`Ring`] with possibly unwritten data.
+    pub fn into_inner(self) -> Ring {
+        self.0
+    }
+
+    const DESCRIPTION: &'static str = "writer panicked, unwritten data may remain";
+}
+
+impl fmt::Display for WriterPanicked {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Self::DESCRIPTION)
+    }
+}
+
+impl fmt::Debug for WriterPanicked {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WriterPanicked")
+            .field(
+                "buffer",
+                &format_args!("{}/{}", self.0.write_len(), self.0.write_capacity()),
+            )
+            .finish()
     }
 }

--- a/src/io/buffer.rs
+++ b/src/io/buffer.rs
@@ -1,7 +1,11 @@
 use super::{Ring, SeqRead, SeqWrite};
 use crate::Result;
 
-use std::io::{self, BufRead, ErrorKind, Read, Write};
+use std::{
+    fmt,
+    io::{self, BufRead, ErrorKind, Read, Write},
+    ops::{Deref, DerefMut},
+};
 
 /// The `BufReader` adds buffering to any reader using a specialized buffer.
 ///
@@ -75,6 +79,42 @@ impl<R: Read> BufReader<R> {
     /// Unwraps this `BufReader`, returning the underlying reader.
     pub fn into_inner(self) -> R {
         self.inner
+    }
+}
+
+impl<R: Read> Deref for BufReader<R> {
+    type Target = R;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.get_ref()
+    }
+}
+
+impl<R: Read> DerefMut for BufReader<R> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.get_mut()
+    }
+}
+
+impl<R> AsRef<R> for BufReader<R>
+where
+    R: Read,
+    <BufReader<R> as Deref>::Target: AsRef<R>,
+{
+    fn as_ref(&self) -> &R {
+        self.deref()
+    }
+}
+
+impl<R> AsMut<R> for BufReader<R>
+where
+    R: Read,
+    <BufReader<R> as Deref>::Target: AsMut<R>,
+{
+    fn as_mut(&mut self) -> &mut R {
+        self.deref_mut()
     }
 }
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,13 +1,12 @@
 //! Read/Write types for buffering.
 //!
-//! Both the [`Ring`](struct.Ring.html) and
-//! [`InfiniteRing`](struct.InfiniteRing.html) are fixed size anonymous allocations
+//! Both the [`Ring`] and [`InfiniteRing`] are fixed size anonymous allocations
 //! utilizing circular address mappinng. The circular mapping ensures that
 //! the entire readable or writable slice may always be addressed as a single,
 //! contiguous allocation. However, these two types differ in one key way:
-//! the [`Ring`](struct.Ring.html) may only written to as readable space
-//! is consumed, whereas the [`InfiniteRing`](struct.InfiniteRing.html) is always
-//! writable and will overwrite unconsumed space as needed.
+//! the [`Ring`] may only written to as readable space is consumed, whereas
+//! the [`InfiniteRing`] is always writable and will overwrite unconsumed
+//! space as needed.
 
 mod ring;
 pub use self::ring::*;

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -178,7 +178,7 @@ mod tests {
                     let read = buf.as_read_slice(word_size);
                     let read_u16 = u16::from_ne_bytes(read[0..2].try_into().unwrap());
                     let expe = &((expected & 0xffff) as u16).to_ne_bytes();
-                    let read_page = (expected - start_val)*word_size / page_size;
+                    let read_page = (expected - start_val) * word_size / page_size;
                     if read != expe {
                         if !mismatched {
                             println!(

--- a/src/io/ring.rs
+++ b/src/io/ring.rs
@@ -79,6 +79,14 @@ impl Ring {
             wpos: 0,
         })
     }
+
+    /// Clears the buffer, resetting the filled region to empty.
+    ///
+    /// The number of initialized bytes is not changed, and the contents of the buffer are not modified.
+    pub fn clear(&mut self) {
+        self.rpos = 0;
+        self.wpos = 0;
+    }
 }
 
 impl Drop for Ring {
@@ -91,9 +99,11 @@ impl SeqRead for Ring {
     fn as_read_ptr(&self) -> *const u8 {
         self.ptr
     }
+
     fn read_offset(&self) -> usize {
         self.rpos as usize % self.len
     }
+
     fn read_len(&self) -> usize {
         (self.wpos - self.rpos) as usize
     }
@@ -103,17 +113,20 @@ impl SeqWrite for Ring {
     fn as_write_ptr(&mut self) -> *mut u8 {
         self.ptr
     }
+
     fn write_offset(&self) -> usize {
         self.wpos as usize % self.len
     }
+
     fn write_len(&self) -> usize {
         self.write_capacity() - self.read_len()
     }
+
     fn write_capacity(&self) -> usize {
         self.len
     }
+
     fn feed(&mut self, len: usize) {
-        // todo will fail at u64 boundary
         self.wpos += cmp::min(len, self.write_len()) as u64;
     }
 }

--- a/src/io/ring.rs
+++ b/src/io/ring.rs
@@ -4,6 +4,7 @@ use crate::{Result, Size};
 
 use std::cmp;
 use std::io::{self, BufRead, Read, Write};
+use std::ops::Deref;
 
 /// Fixed-size reliable read/write buffer with sequential address mapping.
 ///
@@ -143,6 +144,24 @@ impl Write for Ring {
     }
 }
 
+impl Deref for Ring {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_read_slice(usize::MAX)
+    }
+}
+
+impl AsRef<[u8]> for Ring
+where
+    <Ring as Deref>::Target: AsRef<[u8]>,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.deref()
+    }
+}
+
 /// Fixed-size lossy read/write buffer with sequential address mapping.
 ///
 /// This uses a circular address mapping scheme. That is, for any buffer of
@@ -221,7 +240,7 @@ impl SeqRead for InfiniteRing {
         self.ptr
     }
     fn read_offset(&self) -> usize {
-        (self.wpos - self.rlen)as usize % self.len
+        (self.wpos - self.rlen) as usize % self.len
     }
     fn read_len(&self) -> usize {
         self.rlen as usize
@@ -282,5 +301,23 @@ impl Write for InfiniteRing {
 
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+impl Deref for InfiniteRing {
+    type Target = [u8];
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_read_slice(usize::MAX)
+    }
+}
+
+impl AsRef<[u8]> for InfiniteRing
+where
+    <InfiniteRing as Deref>::Target: AsRef<[u8]>,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.deref()
     }
 }

--- a/src/io/ring.rs
+++ b/src/io/ring.rs
@@ -13,10 +13,10 @@ use std::ops::Deref;
 /// memory as the range `N..2*N`. This guarantees that the entire read or
 /// write range may be addressed as a single sequence of bytes.
 ///
-/// Unlike the [`InfiniteRing`](struct.InfiniteRing.html), this type otherise
-/// acts as a "normal" buffer. Writes fill up the buffer, and when full, no
-/// furthur writes may be performed until a read occurs. The writable length
-/// sequence is the capacity of the buffer, less any pending readable bytes.
+/// Unlike the [`InfiniteRing`], this type otherise acts as a "normal" buffer.
+/// Writes fill up the buffer, and when full, no furthur writes may be
+/// performed until a read occurs. The writable length sequence is the capacity
+/// of the buffer, less any pending readable bytes.
 ///
 /// # Examples
 ///
@@ -182,9 +182,9 @@ where
 /// memory as the range `N..2*N`. This guarantees that the entire read or
 /// write range may be addressed as a single sequence of bytes.
 ///
-/// Unlike the [`Ring`](struct.Ring.html), writes to this type may evict
-/// bytes from the read side of the queue. The writeable size is always equal
-/// to the overall capacity of the buffer.
+/// Unlike the [`Ring`], writes to this type may evict bytes from the read side
+/// of the queue. The writeable size is always equal to the overall capacity of
+/// the buffer.
 ///
 /// # Examples
 ///

--- a/src/map.rs
+++ b/src/map.rs
@@ -99,11 +99,11 @@ impl Map {
     /// # }
     /// ```
     pub fn into_map_mut(self) -> ConvertResult<MapMut, Self> {
-            let (ptr, len) = unsafe { Size::page().bounds(self.0.ptr, self.0.len) };
-            match unsafe { protect(ptr, len, Protect::ReadWrite) }{
-                Ok(()) => Ok(self.0),
-                Err(err) => Err((err, self)),
-            }
+        let (ptr, len) = unsafe { Size::page().bounds(self.0.ptr, self.0.len) };
+        match unsafe { protect(ptr, len, Protect::ReadWrite) } {
+            Ok(()) => Ok(self.0),
+            Err(err) => Err((err, self)),
+        }
     }
 
     /// Updates the advise for the entire mapped region..
@@ -164,7 +164,10 @@ impl Deref for Map {
     }
 }
 
-impl AsRef<[u8]> for Map {
+impl AsRef<[u8]> for Map
+where
+    <Map as Deref>::Target: AsRef<[u8]>,
+{
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.deref()
@@ -284,11 +287,11 @@ impl MapMut {
     /// # }
     /// ```
     pub fn into_map(self) -> ConvertResult<Map, Self> {
-            let (ptr, len) = unsafe { Size::page().bounds(self.ptr, self.len) };
-            match unsafe { protect(ptr, len, Protect::ReadWrite) }{
-                Ok(()) => Ok(Map(self)),
-                Err(err) => Err((err, self)),
-            }
+        let (ptr, len) = unsafe { Size::page().bounds(self.ptr, self.len) };
+        match unsafe { protect(ptr, len, Protect::ReadWrite) } {
+            Ok(()) => Ok(Map(self)),
+            Err(err) => Err((err, self)),
+        }
     }
 
     /// Writes modifications back to the filesystem.
@@ -430,14 +433,20 @@ impl DerefMut for MapMut {
     }
 }
 
-impl AsRef<[u8]> for MapMut {
+impl AsRef<[u8]> for MapMut
+where
+    <MapMut as Deref>::Target: AsRef<[u8]>,
+{
     #[inline]
     fn as_ref(&self) -> &[u8] {
         self.deref()
     }
 }
 
-impl AsMut<[u8]> for MapMut {
+impl AsMut<[u8]> for MapMut
+where
+    <MapMut as Deref>::Target: AsMut<[u8]>,
+{
     #[inline]
     fn as_mut(&mut self) -> &mut [u8] {
         self.deref_mut()


### PR DESCRIPTION
This change mostly expands the traits implemented:

- Improved or added `AsMut` and `AsRef` to `Map`, `MapMut`, `BufReader`, `BufWriter`, `Ring`, and `InfiniteRing`.
- Added pass-through `Write` for `BufReader` and `Read` for `BufWriter` if the underlying value implements the respective trait.
-  Added pass-through methods for `Read` and `Write` so that we don't get default implementations.
- Improved `BufWriter::into_inner()`
- Improved `BufWriter` flush behavior surrounding errors.