### PR TITLE
added bytes::Buf and bytes::BufMut support to Ring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,14 @@ edition = "2021"
 
 [features]
 default = ["all"]
-all = ["io", "os"]
+all = ["io", "os", "bytes"]
 io = []
 os = []
+bytes = ["dep:bytes"]
 
 [dependencies]
 system_error = "0.2"
+bytes = { version = "1", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/src/io/bytes.rs
+++ b/src/io/bytes.rs
@@ -1,0 +1,69 @@
+//! Implementations of bytes::BufMut and bytes::Buf for Ring
+
+use std::io::BufRead;
+
+use bytes::{buf::UninitSlice, Buf, BufMut};
+
+use super::{Ring, SeqRead, SeqWrite};
+
+impl Buf for Ring {
+    fn remaining(&self) -> usize {
+        self.read_len()
+    }
+
+    fn chunk(&self) -> &[u8] {
+        self.as_read_slice(usize::MAX)
+    }
+
+    fn advance(&mut self, cnt: usize) {
+        self.consume(cnt)
+    }
+}
+
+unsafe impl BufMut for Ring {
+    fn remaining_mut(&self) -> usize {
+        self.write_len()
+    }
+
+    unsafe fn advance_mut(&mut self, cnt: usize) {
+        self.feed(cnt)
+    }
+
+    fn chunk_mut(&mut self) -> &mut UninitSlice {
+        UninitSlice::new(self.as_write_slice(usize::MAX))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::page_size;
+
+    use super::super::Ring;
+    use bytes::{Buf, BufMut};
+
+    #[test]
+    fn test_bytes_sanity() {
+        let size = page_size();
+        let mut buf = Ring::new(size).expect("failed to create buffer");
+
+        // empty case
+        assert_eq!(buf.remaining(), 0);
+        assert_eq!(buf.chunk().len(), 0);
+        assert_eq!(buf.remaining_mut(), size);
+        assert_eq!(buf.chunk_mut().len(), size);
+
+        // write something
+        buf.put_slice(b"hello world");
+        assert_eq!(buf.remaining(), 11);
+        assert_eq!(buf.chunk(), b"hello world");
+        assert_eq!(buf.remaining_mut(), size - 11);
+        assert_eq!(buf.chunk_mut().len(), size - 11);
+
+        // consume some
+        buf.advance(6);
+        assert_eq!(buf.remaining(), 5);
+        assert_eq!(buf.chunk(), b"world");
+        assert_eq!(buf.remaining_mut(), size - 5);
+        assert_eq!(buf.chunk_mut().len(), size - 5);
+    }
+}

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -9,10 +9,14 @@
 //! space as needed.
 
 mod ring;
+
 pub use self::ring::*;
 
 mod buffer;
 pub use self::buffer::*;
+
+#[cfg(feature = "bytes")]
+pub mod bytes;
 
 use std::cmp;
 use std::io::{self, BufRead};


### PR DESCRIPTION
I would love to have native Buf and BufMut support for easier integration between vmap::Ring and prost. You can find prost here: https://github.com/tokio-rs/prost

Documentation on traits:
* [Buf](https://docs.rs/bytes/latest/bytes/buf/trait.Buf.html)
* [BufMut](https://docs.rs/bytes/latest/bytes/buf/trait.BufMut.html)

Happy to move the code around, add tests, or change features. Not sure how you'd like these kinds of extensions to work.

And thanks for such an awesome crate!